### PR TITLE
Fix build issues caused by addition of metaDigitise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,6 @@ apt_packages:
     - libgsl0ldbl
     - libxml2-dev
 
-r_binary_packages:
-    - Rcpp
-    - RcppGSL
-    - roxygen2
-    - tidyverse
-    - devtools
-    - stringi
-    - covr
-    - qpdf
-
-
 r_build_args: --no-build-vignettes --no-manual
 r_check_args: --no-build-vignettes --no-manual
 
@@ -25,5 +14,3 @@ warnings_are_errors : false
 
 after_success:
   - Rscript -e 'library(covr); codecov()'
-  
-r_github_packages: r-lib/remotes#340

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,5 @@ warnings_are_errors : false
 
 after_success:
   - Rscript -e 'library(covr); codecov()'
+  
+r_github_packages: r-lib/remotes#340

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,3 @@ warnings_are_errors : false
 
 after_success:
   - Rscript -e 'library(covr); codecov()'
-
-before_install: R -e 'source("https://install-github.me/r-lib/remotes")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,5 @@ warnings_are_errors : false
 
 after_success:
   - Rscript -e 'library(covr); codecov()'
+
+before_install: R -e 'source("https://install-github.me/r-lib/remotes")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 
 language: r
 
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libmagick++-dev
+
 apt_packages:
     - libgsl0-dev
     - libgsl0ldbl
@@ -9,6 +13,16 @@ apt_packages:
 
 r_build_args: --no-build-vignettes --no-manual
 r_check_args: --no-build-vignettes --no-manual
+
+r_binary_packages:
+    - Rcpp
+    - RcppGSL
+    - roxygen2
+    - tidyverse
+    - devtools
+    - stringi
+    - covr
+    - qpdf
 
 warnings_are_errors : false
 

--- a/tests/testthat/test-metaverse.r
+++ b/tests/testthat/test-metaverse.r
@@ -6,6 +6,6 @@ test_that("Starts the metaverse package", {
 })
 
 test_that("Number of attached packages", {
-  expect_length(metaverse_packages(include_self = TRUE), 12)
-  expect_length(metaverse_packages(include_self = FALSE), 11)
+  expect_length(metaverse_packages(include_self = TRUE), 13)
+  expect_length(metaverse_packages(include_self = FALSE), 12)
 })


### PR DESCRIPTION
Made two edits, and confirmed that Travis will now build. 

- Added a `before_install` line to .travis.yml to install magick++ library. metaDigitise depends on magick, which in turn requires this library, but for some reason, Travis couldn't install it properly without this line. I sourced this fix from here - https://github.com/travis-ci/travis-ci/issues/9625 
- Updated test-metaverse.r to reflect the addition of metaDigitise